### PR TITLE
[Issue-32] Revise the path of resource files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ jar {
 dependencies {
     compile 'com.github.shineware:commons:1.0.1'
     compile 'com.github.shineware:aho-corasick:1.0.9'
-    compile 'com.google.guava:guava:23.6-jre'
     testCompile 'junit:junit:4.12'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ jar {
 dependencies {
     compile 'com.github.shineware:commons:1.0.1'
     compile 'com.github.shineware:aho-corasick:1.0.9'
+    compile 'com.google.guava:guava:23.6-jre'
     testCompile 'junit:junit:4.12'
 }
 

--- a/src/main/java/kr/co/shineware/nlp/komoran/core/Komoran.java
+++ b/src/main/java/kr/co/shineware/nlp/komoran/core/Komoran.java
@@ -17,7 +17,6 @@
  *******************************************************************************/
 package kr.co.shineware.nlp.komoran.core;
 
-import com.google.common.base.Joiner;
 import kr.co.shineware.ds.aho_corasick.FindContext;
 import kr.co.shineware.nlp.komoran.constant.DEFAULT_MODEL;
 import kr.co.shineware.nlp.komoran.constant.FILENAME;
@@ -75,15 +74,15 @@ public class Komoran implements Cloneable {
             modelPath = FILENAME.FULL_MODEL;
         }
 
-        Joiner joiner = Joiner.on("/").skipNulls();
+        String delimiter = "/";
         InputStream posTableFile =
-            this.getResourceStream(joiner.join(modelPath, FILENAME.POS_TABLE));
+            this.getResourceStream(String.join(delimiter, modelPath, FILENAME.POS_TABLE));
         InputStream irrModelFile =
-            this.getResourceStream(joiner.join(modelPath, FILENAME.IRREGULAR_MODEL));
+            this.getResourceStream(String.join(delimiter, modelPath, FILENAME.IRREGULAR_MODEL));
         InputStream observationFile =
-            this.getResourceStream(joiner.join(modelPath, FILENAME.OBSERVATION));
+            this.getResourceStream(String.join(delimiter, modelPath, FILENAME.OBSERVATION));
         InputStream transitionFile =
-            this.getResourceStream(joiner.join(modelPath, FILENAME.TRANSITION));
+            this.getResourceStream(String.join(delimiter, modelPath, FILENAME.TRANSITION));
 
         this.resources.loadPosTable(posTableFile);
         this.resources.loadIrregular(irrModelFile);

--- a/src/main/java/kr/co/shineware/nlp/komoran/core/Komoran.java
+++ b/src/main/java/kr/co/shineware/nlp/komoran/core/Komoran.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package kr.co.shineware.nlp.komoran.core;
 
+import com.google.common.base.Joiner;
 import kr.co.shineware.ds.aho_corasick.FindContext;
 import kr.co.shineware.nlp.komoran.constant.DEFAULT_MODEL;
 import kr.co.shineware.nlp.komoran.constant.FILENAME;
@@ -73,10 +74,16 @@ public class Komoran implements Cloneable {
         } else {
             modelPath = FILENAME.FULL_MODEL;
         }
-        InputStream posTableFile = this.getResourceStream(modelPath + File.separator + FILENAME.POS_TABLE);
-        InputStream irrModelFile = this.getResourceStream(modelPath + File.separator + FILENAME.IRREGULAR_MODEL);
-        InputStream observationFile = this.getResourceStream(modelPath + File.separator + FILENAME.OBSERVATION);
-        InputStream transitionFile = this.getResourceStream(modelPath + File.separator + FILENAME.TRANSITION);
+
+        Joiner joiner = Joiner.on("/").skipNulls();
+        InputStream posTableFile =
+            this.getResourceStream(joiner.join(modelPath, FILENAME.POS_TABLE));
+        InputStream irrModelFile =
+            this.getResourceStream(joiner.join(modelPath, FILENAME.IRREGULAR_MODEL));
+        InputStream observationFile =
+            this.getResourceStream(joiner.join(modelPath, FILENAME.OBSERVATION));
+        InputStream transitionFile =
+            this.getResourceStream(joiner.join(modelPath, FILENAME.TRANSITION));
 
         this.resources.loadPosTable(posTableFile);
         this.resources.loadIrregular(irrModelFile);


### PR DESCRIPTION
#32 
@shin285 

When importing a resource file in Java, that method assumes "/" seperated path.

> The name of a resource is a /-separated path name that identifies the resource. [JavaDoc](https://docs.oracle.com/javase/7/docs/api/java/lang/ClassLoader.html#getResource(java.lang.String))

```java
modelPath + File.separator + FILENAME.POS_TABLE
```
On Windows, the code `File.separator` is '\\' and will generate an invalid path.
I modified some code and added Google's Guava library to concatenate String efficiently.
If you don't want to increase Jar file size by adding Guava, alternative method such as StringBuilder will be possible.

Feel free to give me a feedback. Thx