### PR TITLE
KOMORAN-54 기분석 사전 적용 시의 분석 결과 이슈

### DIFF
--- a/src/main/java/kr/co/shineware/nlp/komoran/core/model/Lattice.java
+++ b/src/main/java/kr/co/shineware/nlp/komoran/core/model/Lattice.java
@@ -563,6 +563,7 @@ public class Lattice {
             LatticeNode latticeNode = endNode;
             while (true) {
                 latticeNode = this.lattice.get(latticeNode.getBeginIdx()).get(latticeNode.getPrevNodeIdx());
+                //불규칙이거나 multi token 기분석 사전인 경우
                 if (latticeNode.getEndIdx() < 0) {
                     latticeNode.setEndIdx(prevLatticeEndIndex);
                 }

--- a/src/main/java/kr/co/shineware/nlp/komoran/corpus/builder/CorpusBuilder.java
+++ b/src/main/java/kr/co/shineware/nlp/komoran/corpus/builder/CorpusBuilder.java
@@ -128,7 +128,8 @@ public class CorpusBuilder {
             if (suffix != null && filename.endsWith("." + suffix)) {
                 System.out.println(filename);
                 this.build(filename);
-            } else {
+            }
+            if (suffix == null) {
                 System.out.println(filename);
                 this.build(filename);
             }

--- a/src/main/java/kr/co/shineware/nlp/komoran/model/KomoranResult.java
+++ b/src/main/java/kr/co/shineware/nlp/komoran/model/KomoranResult.java
@@ -71,6 +71,7 @@ public class KomoranResult {
             if (latticeNode.getMorphTag().getTag().equals(SYMBOL.END)) {
                 continue;
             }
+            //불규칙이거나 multi token 기분석 사전인 경우
             if (latticeNode.getBeginIdx() < 0) {
                 latticeNode.setBeginIdx(prevBeginIdx);
             }

--- a/src/test/java/kr/co/shineware/nlp/komoran/core/KomoranTest.java
+++ b/src/test/java/kr/co/shineware/nlp/komoran/core/KomoranTest.java
@@ -163,8 +163,12 @@ public class KomoranTest {
 
     @Test
     public void setFWDic() {
+        KomoranResult komoranResult = this.komoran.analyze("감기는");
+        System.out.println(komoranResult.getTokenList());
         this.komoran.setFWDic("user_data/fwd.user");
         this.komoran.analyze("감사합니다! 바람과 함께 사라지다는 진짜 재밌었어요! nice good!");
+        komoranResult = this.komoran.analyze("감기는");
+        System.out.println(komoranResult.getTokenList());
     }
 
     @Test


### PR DESCRIPTION
Resolve #54 
기분석 사전 어절과 분석 결과의 문자열이 일치하는 경우에 인덱스 번호가 정상적으로 수정되도록 변경
단, 기분석 사전 어절과 분석 결과의 문자열이 불일치하는 경우에는 인덱스 번호를 처리 할 수 없음
분석 결과 확인을 위한 테스트 케이스 추가