### PR TITLE
Add fatJar command in gradle script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,15 @@ dependencies {
     testCompile 'junit:junit:4.12'
 }
 
+task uberJar(type: Jar) {
+    appendix = 'uber'
+
+    from sourceSets.main.output
+    from configurations.runtimeClasspath
+            .findAll { it.name.endsWith('jar') }
+            .collect { zipTree(it) }
+}
+
 compileJava.options.encoding = "UTF-8"
 compileTestJava.options.encoding = "UTF-8"
 


### PR DESCRIPTION
## 관련 이슈 또는 PR 번호
#81 #82 

## PR 종류
_이 PR에 해당되는 내용을 선택해주세요._

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 문서 변경 (또는 문서 변경 필요)
- [ ] 호환성 변경

## PR 설명
gradle script에서 fatJar 커맨드 지원  ( https://docs.gradle.org/4.10.2/userguide/working_with_files.html#sec:creating_uber_jar_example
 )
다만 기존 파일에서 22~39 line도 같은 동작을 하는 부분으로 보여서, 둘중 하나를 취사선택하는 것이 좋을 것으로 보임