### PR TITLE
n-best bug fixed. Added exception join rule in lattice

### DIFF
--- a/src/main/java/kr/co/shineware/nlp/komoran/constant/SYMBOL.java
+++ b/src/main/java/kr/co/shineware/nlp/komoran/constant/SYMBOL.java
@@ -49,4 +49,9 @@ public class SYMBOL {
 	public static final String NNB = "NNB";
 
 	public static final String JKB = "JKB";
+	public static final String VV = "VV";
+	public static final String VA = "VA";
+	public static final String VX = "VX";
+	public static final String VCP = "VCP";
+	public static final String VCN = "VCN";
 }

--- a/src/test/java/kr/co/shineware/nlp/komoran/issue/AnalyzeIssues.java
+++ b/src/test/java/kr/co/shineware/nlp/komoran/issue/AnalyzeIssues.java
@@ -26,4 +26,11 @@ public class AnalyzeIssues {
         Assert.assertNotEquals(komoran.analyze("미남로", 2).get(0).getPlainText(),"미남/NNG 로/JKB");
         Assert.assertNotEquals(komoran.analyze("구남로", 2).get(0).getPlainText(),"구남/NNG 로/JKB");
     }
+
+    @Test
+    //https://github.com/shin285/KOMORAN/issues/75
+    public void issue75(){
+        Assert.assertNotEquals(komoran.analyze("가을").getPlainText(),"가/VV 을/ETM");
+        Assert.assertNotEquals(komoran.analyze("가을", 2).get(0).getPlainText(),"가/VV 을/ETM");
+    }
 }


### PR DESCRIPTION
## 관련 이슈 또는 PR 번호
- Resolved #75
- 기타 버그 수정

## PR 종류
- [x] 버그 수정

## PR 설명
- `가을`이 `가/VV+을/ETM`으로 분석되는 문제 수정
  - 종성이 없는 용언 뒤에 명사형 전성어미 `을`이 붙었을 때 결합하지 않는 규칙 추가
- n-best 로직 적용 시 마지막 노드에 대한 transition score가 적용되지 않던 문제 수정
- n-best 적용 시 score 값으로 sorting 되지 않던 버그 수정
