### PR TITLE
"황토은"이 황토/NNG 은/JX로 분석되는 문제

### DIFF
--- a/src/main/java/kr/co/shineware/nlp/komoran/constant/SYMBOL.java
+++ b/src/main/java/kr/co/shineware/nlp/komoran/constant/SYMBOL.java
@@ -55,4 +55,5 @@ public class SYMBOL {
 	public static final String VCP = "VCP";
 	public static final String VCN = "VCN";
 	public static final String NP = "NP";
+	public static final String JC = "JC";
 }

--- a/src/main/java/kr/co/shineware/nlp/komoran/constant/SYMBOL.java
+++ b/src/main/java/kr/co/shineware/nlp/komoran/constant/SYMBOL.java
@@ -54,4 +54,5 @@ public class SYMBOL {
 	public static final String VX = "VX";
 	public static final String VCP = "VCP";
 	public static final String VCN = "VCN";
+	public static final String NP = "NP";
 }

--- a/src/main/java/kr/co/shineware/nlp/komoran/core/model/Lattice.java
+++ b/src/main/java/kr/co/shineware/nlp/komoran/core/model/Lattice.java
@@ -304,7 +304,14 @@ public class Lattice {
                         continue;
                     }
                 }
-            } else if (tagId == this.posTable.getId(SYMBOL.JX) && morph.charAt(0) == 'ㅇ') {
+                if (this.isNoun(prevTagId)) {
+                    continue;
+                }
+
+            } else if (
+                    (tagId == this.posTable.getId(SYMBOL.JX)
+                            || tagId == this.posTable.getId(SYMBOL.JC)
+                    ) && morph.charAt(0) == 'ㅇ') {
                 if (!this.hasJongsung(prevMorph) && this.isNoun(prevTagId)) {
                     continue;
                 }
@@ -409,7 +416,14 @@ public class Lattice {
                         continue;
                     }
                 }
-            } else if (tagId == this.posTable.getId(SYMBOL.JX) && morph.charAt(0) == 'ㅇ') {
+                if (this.isNoun(prevTagId)) {
+                    continue;
+                }
+
+            } else if (
+                    (tagId == this.posTable.getId(SYMBOL.JX)
+                            || tagId == this.posTable.getId(SYMBOL.JC)
+                    ) && morph.charAt(0) == 'ㅇ') {
                 if (!this.hasJongsung(prevMorph) && this.isNoun(prevTagId)) {
                     continue;
                 }

--- a/src/main/java/kr/co/shineware/nlp/komoran/core/model/Lattice.java
+++ b/src/main/java/kr/co/shineware/nlp/komoran/core/model/Lattice.java
@@ -298,12 +298,15 @@ public class Lattice {
                 if (this.hasJongsung(prevMorph)) {
                     continue;
                 }
-            }
-            else if (tagId == this.posTable.getId(SYMBOL.ETM)) {
-                if (!this.hasJongsung(prevMorph) && this.isPredicate(prevTagId)){
+            } else if (tagId == this.posTable.getId(SYMBOL.ETM)) {
+                if (!this.hasJongsung(prevMorph) && this.isPredicate(prevTagId)) {
                     if (morph.equals("ㅇㅡㄹ")) {
                         continue;
                     }
+                }
+            } else if (tagId == this.posTable.getId(SYMBOL.JX) && morph.charAt(0) == 'ㅇ') {
+                if (!this.hasJongsung(prevMorph) && this.isNoun(prevTagId)) {
+                    continue;
                 }
             }
 
@@ -337,6 +340,12 @@ public class Lattice {
             return nbestPrevNodeList;
         }
         return null;
+    }
+
+    private boolean isNoun(int prevTagId) {
+        return prevTagId == this.posTable.getId(SYMBOL.NNG)
+                || prevTagId == this.posTable.getId(SYMBOL.NNP)
+                || prevTagId == this.posTable.getId(SYMBOL.NP);
     }
 
     private LatticeNode getMaxTransitionNodeFromPrevNodes(
@@ -394,12 +403,15 @@ public class Lattice {
                 if (this.hasJongsung(prevMorph)) {
                     continue;
                 }
-            }
-            else if (tagId == this.posTable.getId(SYMBOL.ETM)) {
-                if (!this.hasJongsung(prevMorph) && this.isPredicate(prevTagId)){
+            } else if (tagId == this.posTable.getId(SYMBOL.ETM)) {
+                if (!this.hasJongsung(prevMorph) && this.isPredicate(prevTagId)) {
                     if (morph.equals("ㅇㅡㄹ")) {
                         continue;
                     }
+                }
+            } else if (tagId == this.posTable.getId(SYMBOL.JX) && morph.charAt(0) == 'ㅇ') {
+                if (!this.hasJongsung(prevMorph) && this.isNoun(prevTagId)) {
+                    continue;
                 }
             }
 
@@ -618,7 +630,7 @@ public class Lattice {
 
         }
 
-        if(nBestShortestPathList.size() > 1){
+        if (nBestShortestPathList.size() > 1) {
             nBestShortestPathList = sortNBestByScore(nBestShortestPathList);
         }
 
@@ -628,7 +640,7 @@ public class Lattice {
     private List<List<LatticeNode>> sortNBestByScore(List<List<LatticeNode>> nBestShortestPathList) {
         Map<List<LatticeNode>, Double> sortedLatticeNodeList = new HashMap<>();
         for (List<LatticeNode> latticeNodes : nBestShortestPathList) {
-            double score = latticeNodes.get(latticeNodes.size()-1).getScore();
+            double score = latticeNodes.get(latticeNodes.size() - 1).getScore();
             sortedLatticeNodeList.put(latticeNodes, score);
         }
 

--- a/src/test/java/kr/co/shineware/nlp/komoran/issue/AnalyzeIssues.java
+++ b/src/test/java/kr/co/shineware/nlp/komoran/issue/AnalyzeIssues.java
@@ -37,13 +37,18 @@ public class AnalyzeIssues {
     @Test
     //https://github.com/shin285/KOMORAN/issues/77
     public void issue77() {
-        System.out.println(komoran.analyze("황토은").getPlainText());
-        System.out.println(komoran.analyze("황토은", 2).get(0).getPlainText());
-        Assert.assertNotEquals("황토/NNG 은/JX", komoran.analyze("황토은").getPlainText());
-        Assert.assertNotEquals("황토/NNG 은/JX", komoran.analyze("황토은", 2).get(0).getPlainText());
-        Assert.assertNotEquals("황토/NNG 은/JC", komoran.analyze("황토은").getPlainText());
-        Assert.assertNotEquals("황토/NNG 은/JC", komoran.analyze("황토은", 2).get(0).getPlainText());
-        Assert.assertEquals("황토/NNG 은/NNG", komoran.analyze("황토은").getPlainText());
-        Assert.assertEquals("황토/NNG 은/NNG", komoran.analyze("황토은", 2).get(0).getPlainText());
+
+        String analyzeTarget = "황토은";
+
+        String analyzeResult = komoran.analyze(analyzeTarget).getPlainText();
+        String nBestAnalyzeResult = komoran.analyze(analyzeTarget, 2).get(0).getPlainText();
+
+        Assert.assertEquals(analyzeResult, nBestAnalyzeResult);
+        Assert.assertNotEquals("황토/NNG 은/JX", analyzeResult);
+        Assert.assertNotEquals("황토/NNG 은/JX", nBestAnalyzeResult);
+        Assert.assertNotEquals("황토/NNG 은/JC", analyzeResult);
+        Assert.assertNotEquals("황토/NNG 은/JC", nBestAnalyzeResult);
+        Assert.assertEquals("황토/NNG 은/NNG", analyzeResult);
+        Assert.assertEquals("황토/NNG 은/NNG", nBestAnalyzeResult);
     }
 }

--- a/src/test/java/kr/co/shineware/nlp/komoran/issue/AnalyzeIssues.java
+++ b/src/test/java/kr/co/shineware/nlp/komoran/issue/AnalyzeIssues.java
@@ -18,19 +18,27 @@ public class AnalyzeIssues {
     @Test
     //https://github.com/shin285/KOMORAN/issues/74
     public void issue74() {
-        Assert.assertNotEquals(komoran.analyze("대학로").getPlainText(),"대학/NNG 로/JKB");
-        Assert.assertNotEquals(komoran.analyze("미남로").getPlainText(),"미남/NNG 로/JKB");
-        Assert.assertNotEquals(komoran.analyze("구남로").getPlainText(),"구남/NNG 로/JKB");
+        Assert.assertNotEquals(komoran.analyze("대학로").getPlainText(), "대학/NNG 로/JKB");
+        Assert.assertNotEquals(komoran.analyze("미남로").getPlainText(), "미남/NNG 로/JKB");
+        Assert.assertNotEquals(komoran.analyze("구남로").getPlainText(), "구남/NNG 로/JKB");
 
-        Assert.assertNotEquals(komoran.analyze("대학로", 2).get(0).getPlainText(),"대학/NNG 로/JKB");
-        Assert.assertNotEquals(komoran.analyze("미남로", 2).get(0).getPlainText(),"미남/NNG 로/JKB");
-        Assert.assertNotEquals(komoran.analyze("구남로", 2).get(0).getPlainText(),"구남/NNG 로/JKB");
+        Assert.assertNotEquals(komoran.analyze("대학로", 2).get(0).getPlainText(), "대학/NNG 로/JKB");
+        Assert.assertNotEquals(komoran.analyze("미남로", 2).get(0).getPlainText(), "미남/NNG 로/JKB");
+        Assert.assertNotEquals(komoran.analyze("구남로", 2).get(0).getPlainText(), "구남/NNG 로/JKB");
     }
 
     @Test
     //https://github.com/shin285/KOMORAN/issues/75
-    public void issue75(){
-        Assert.assertNotEquals(komoran.analyze("가을").getPlainText(),"가/VV 을/ETM");
-        Assert.assertNotEquals(komoran.analyze("가을", 2).get(0).getPlainText(),"가/VV 을/ETM");
+    public void issue75() {
+        Assert.assertNotEquals(komoran.analyze("가을").getPlainText(), "가/VV 을/ETM");
+        Assert.assertNotEquals(komoran.analyze("가을", 2).get(0).getPlainText(), "가/VV 을/ETM");
+    }
+
+    @Test
+    //https://github.com/shin285/KOMORAN/issues/77
+    public void issue77() {
+        System.out.println(komoran.analyze("황토은").getPlainText());
+        System.out.println(komoran.analyze("나은").getPlainText());
+        Assert.assertNotEquals(komoran.analyze("황토은").getPlainText(), "황토/NNG 은/JX");
     }
 }

--- a/src/test/java/kr/co/shineware/nlp/komoran/issue/AnalyzeIssues.java
+++ b/src/test/java/kr/co/shineware/nlp/komoran/issue/AnalyzeIssues.java
@@ -18,27 +18,32 @@ public class AnalyzeIssues {
     @Test
     //https://github.com/shin285/KOMORAN/issues/74
     public void issue74() {
-        Assert.assertNotEquals(komoran.analyze("대학로").getPlainText(), "대학/NNG 로/JKB");
-        Assert.assertNotEquals(komoran.analyze("미남로").getPlainText(), "미남/NNG 로/JKB");
-        Assert.assertNotEquals(komoran.analyze("구남로").getPlainText(), "구남/NNG 로/JKB");
+        Assert.assertNotEquals("대학/NNG 로/JKB", komoran.analyze("대학로").getPlainText());
+        Assert.assertNotEquals("미남/NNG 로/JKB", komoran.analyze("미남로").getPlainText());
+        Assert.assertNotEquals("구남/NNG 로/JKB", komoran.analyze("구남로").getPlainText());
 
-        Assert.assertNotEquals(komoran.analyze("대학로", 2).get(0).getPlainText(), "대학/NNG 로/JKB");
-        Assert.assertNotEquals(komoran.analyze("미남로", 2).get(0).getPlainText(), "미남/NNG 로/JKB");
-        Assert.assertNotEquals(komoran.analyze("구남로", 2).get(0).getPlainText(), "구남/NNG 로/JKB");
+        Assert.assertNotEquals("대학/NNG 로/JKB", komoran.analyze("대학로", 2).get(0).getPlainText());
+        Assert.assertNotEquals("미남/NNG 로/JKB", komoran.analyze("미남로", 2).get(0).getPlainText());
+        Assert.assertNotEquals("구남/NNG 로/JKB", komoran.analyze("구남로", 2).get(0).getPlainText());
     }
 
     @Test
     //https://github.com/shin285/KOMORAN/issues/75
     public void issue75() {
-        Assert.assertNotEquals(komoran.analyze("가을").getPlainText(), "가/VV 을/ETM");
-        Assert.assertNotEquals(komoran.analyze("가을", 2).get(0).getPlainText(), "가/VV 을/ETM");
+        Assert.assertNotEquals("가/VV 을/ETM", komoran.analyze("가을").getPlainText());
+        Assert.assertNotEquals("가/VV 을/ETM", komoran.analyze("가을", 2).get(0).getPlainText());
     }
 
     @Test
     //https://github.com/shin285/KOMORAN/issues/77
     public void issue77() {
         System.out.println(komoran.analyze("황토은").getPlainText());
-        System.out.println(komoran.analyze("나은").getPlainText());
-        Assert.assertNotEquals(komoran.analyze("황토은").getPlainText(), "황토/NNG 은/JX");
+        System.out.println(komoran.analyze("황토은", 2).get(0).getPlainText());
+        Assert.assertNotEquals("황토/NNG 은/JX", komoran.analyze("황토은").getPlainText());
+        Assert.assertNotEquals("황토/NNG 은/JX", komoran.analyze("황토은", 2).get(0).getPlainText());
+        Assert.assertNotEquals("황토/NNG 은/JC", komoran.analyze("황토은").getPlainText());
+        Assert.assertNotEquals("황토/NNG 은/JC", komoran.analyze("황토은", 2).get(0).getPlainText());
+        Assert.assertEquals("황토/NNG 은/NNG", komoran.analyze("황토은").getPlainText());
+        Assert.assertEquals("황토/NNG 은/NNG", komoran.analyze("황토은", 2).get(0).getPlainText());
     }
 }


### PR DESCRIPTION
## 관련 이슈 또는 PR 번호
Resolved #77 

## PR 종류

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 문서 변경 (또는 문서 변경 필요)
- [ ] 호환성 변경

## PR 설명
`황토은`이 `황토/NNG + 은/JX`으로 분석되던 문제가 해결되었습니다.
`황토은` 분석 시 `황토/NNG + 은/NNG`로 정상 분석되는 것을 확인하였습니다.